### PR TITLE
Make scalajs-bundler plugin optional.

### DIFF
--- a/sbtgen/src/main/scala/izumi/sbtgen/Entrypoint.scala
+++ b/sbtgen/src/main/scala/izumi/sbtgen/Entrypoint.scala
@@ -132,10 +132,17 @@ object Entrypoint {
            |
            |// https://github.com/portable-scala/sbt-crossproject
            |addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % ${renderer renderVersion config.settings.crossProjectVersion})
-           |
-           |// https://scalacenter.github.io/scalajs-bundler/
-           |addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % ${renderer renderVersion config.settings.bundlerVersion})
-           |""".stripMargin)
+           |""".stripMargin
+      )
+
+      config.settings.bundlerVersion.foreach { bv =>
+        b.append(
+         s"""|
+             |// https://scalacenter.github.io/scalajs-bundler/
+             |addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % ${renderer renderVersion bv})
+             |""".stripMargin
+        )
+      }
     }
 
     if (config.native) {

--- a/sbtgen/src/main/scala/izumi/sbtgen/model/GlobalSettings.scala
+++ b/sbtgen/src/main/scala/izumi/sbtgen/model/GlobalSettings.scala
@@ -6,6 +6,6 @@ case class GlobalSettings(
                            scalaJsVersion: Version = Version.VConst("0.6.32"),
                            scalaNativeVersion: Version = Version.VConst("0.4.0-M2"),
                            crossProjectVersion: Version = Version.VConst("1.0.0"),
-                           bundlerVersion: Version = Version.VConst("0.14.0"),
+                           bundlerVersion: Option[Version] = Some(Version.VConst("0.14.0")),
                            sbtDottyVersion: Version = Version.VConst("0.4.1"),
                          )


### PR DESCRIPTION
ScalaJS bundler plugin has since 0.16 different name for ScalaJS 0.6 - adds suffix _sjs06. I briefly considered making the generator aware of that and generating conditional code by the version, but that would result in ugly if's in plugins.sbt, and everone will migrate to 1.0 eventually anyway, which will make it unnecessary.

It seemed better to make the bundlerVersion in GlobalSettings optional. Present by default, if set to None, it will skip the scalajs-bundler plugin output. This allows someone not use scalajs-bundler at all, or supply other (_sjs06) version, if needed.